### PR TITLE
Added expandable cards with a RSVP button

### DIFF
--- a/components/EventCard/EventCard.component.js
+++ b/components/EventCard/EventCard.component.js
@@ -1,18 +1,46 @@
-import React from 'react';
-import { Text, Image, TouchableWithoutFeedback, View } from 'react-native';
+import React, { useState } from 'react';
+import { Text, Image, TouchableWithoutFeedback, View, Button, Alert } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 
 import styles from './EventCard.styles';
+import Modal from 'react-native-modal';
 
 const EventCard = (props) => {
+
+    const [isModalVisible, setModalVisible] = useState(false);
+
+    const toggleModal = () => {
+        setModalVisible(!isModalVisible);
+    };
+
     return(
-        <TouchableOpacity style={styles.container} onPress={props.onPress}>
-            <Text> {props.org} </Text>
-            <Text style={styles.title}> {props.title} </Text>
-            <Image style={styles.image} resizeMode="contain" source={props.source}/>
-            <Text style={styles.date}> {props.date} </Text>
-            <Text> {props.link} </Text>
-        </TouchableOpacity>
+        <View>
+            <TouchableOpacity style={styles.container} onPress={toggleModal}>
+                <Text> {props.org} </Text>
+                <Text style={styles.title}> {props.title} </Text>
+                <Image style={styles.image} resizeMode="contain" source={props.source}/>
+                <Text style={styles.date}> {props.date} </Text>
+                <Text> {props.link} </Text>
+            </TouchableOpacity>
+            <Modal isVisible={isModalVisible}>
+                <View style={styles.containerPopUp}>
+                    <Text> {props.org} </Text>
+                    <Text style={styles.titlePopUp}> {props.title} </Text>
+                    <Image style={styles.imagePopUp} resizeMode="contain" source={props.source} />
+                    <Text style={styles.datePopUp}> {props.date} </Text>
+                    <Text> {props.link} </Text>
+                    <TouchableOpacity style={styles.btnPopUp}>
+                        <Text style={styles.btnText} 
+                        onPress={
+                            () => Alert.alert("You successfully have registered for " + props.title + " on " + props.date + "!")
+                        }>RSVP</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity style={styles.btnPopUp}>
+                        <Text style={styles.btnText} onPress={toggleModal}>Exit</Text>
+                    </TouchableOpacity>
+                </View>
+            </Modal>
+        </View>
     )
 }
 

--- a/components/EventCard/EventCard.styles.js
+++ b/components/EventCard/EventCard.styles.js
@@ -36,6 +36,52 @@ const styles = StyleSheet.create({
         borderRadius: 10,
     },
     date: {
+    },
+
+    containerPopUp: {
+        marginTop: 10,
+        //flex: 1,
+        //flexDirection: 'row',
+        //justifyContent: 'space-between',
+        backgroundColor: 'white',
+        // width: width - 40,
+        margin: 10,
+        // height: height - 105,
+        alignItems: 'center',
+        borderRadius: 10,
+        padding: "5%",
+        shadowColor: 'black',
+        shadowOffset: {
+            width: 1,
+            height: 1
+        },
+        shadowOpacity: 0.24,
+        shadowRadius: 5,
+        elevation: 3
+    },
+    titlePopUp: {
+        fontWeight: 'bold',
+        fontSize: 25,
+    },
+    imagePopUp: {
+        width: "100%",
+        height: "70%",
+        //margin: "5%",
+        borderRadius: 10,
+    },
+    datePopUp: {
+    },
+    btnPopUp: {
+        backgroundColor: '#92d050',
+        padding: 5,
+        margin: 5,
+        width: 100,
+        borderRadius: 10,
+    },
+    btnText: {
+        textAlign: 'center',
+        textTransform: 'uppercase',
+        fontWeight: 'bold'
     }
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9970,6 +9970,14 @@
         }
       }
     },
+    "react-native-animatable": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/react-native-animatable/-/react-native-animatable-1.3.3.tgz",
+      "integrity": "sha512-2ckIxZQAsvWn25Ho+DK3d1mXIgj7tITkrS4pYDvx96WyOttSvzzFeQnM2od0+FUMzILbdHDsDEqZvnz1DYNQ1w==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-native-gesture-handler": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.8.0.tgz",
@@ -9985,6 +9993,15 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz",
       "integrity": "sha512-/VbpIEp8tSNNHIvstuA3Swx610whci1Zpc9mqNkqn14DkMbw+ORviln2u0XyHG1kPvvwTNGZY6QpeFwxYaSdbQ=="
+    },
+    "react-native-modal": {
+      "version": "11.5.6",
+      "resolved": "https://registry.npmjs.org/react-native-modal/-/react-native-modal-11.5.6.tgz",
+      "integrity": "sha512-APGNfbvgC4hXbJqcSADu79GLoMKIHUmgR3fDQ7rCGZNBypkStSP8imZ4PKK/OzIZZfjGU9aP49jhMgGbhY9KHA==",
+      "requires": {
+        "prop-types": "^15.6.2",
+        "react-native-animatable": "1.3.3"
+      }
     },
     "react-native-paper": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "16.13.1",
     "react-native": "0.63.3",
     "react-native-gesture-handler": "^1.8.0",
+    "react-native-modal": "^11.5.6",
     "react-native-paper": "^4.2.0",
     "react-native-reanimated": "^1.13.1",
     "react-native-safe-area-context": "^3.1.8",


### PR DESCRIPTION
# Implemented Features
- Cards pop up on screen when tapped with background darkened and disabled (no scrolling, pressing buttons outside the window, etc)
- When a card is popped up, user can press the RSVP button. If the user does, they will get an Alert that notifies the user that he or she has successfully registered to the event and displays the event name and date.
- User can also exit the card by pressing the Exit button below it.

# Other Notes
- Attempted to copy the Main Button style, so change it if it looks bad.
- The Blizzard Event card text is too long and messes up the margin for the Exit button.
- The Blizzard Event card title is too long for the Alert to fit into the Alert box. It cuts off with "..."

# NPM Installed
- npm i react-native-modal
- https://github.com/react-native-modal/react-native-modal