### PR TITLE
Changed Feed page cards like Club page cards

### DIFF
--- a/components/EventCard/EventCard.styles.js
+++ b/components/EventCard/EventCard.styles.js
@@ -74,22 +74,12 @@ const styles = StyleSheet.create({
         textAlign: 'left',
         width: '100%',
         paddingVertical: '2%'
-
     },
     datePopUp: {
         fontSize: 20,
         fontWeight: 'bold'
         
     },
-    btnText: {
-        fontSize: 20,
-        textAlign: 'center',
-        textTransform: 'uppercase',
-        fontWeight: 'bold',
-        letterSpacing: 2
-    }
-
- 
 });
 
 export default styles;

--- a/components/SubscribedCard/SubscribedCard.component.js
+++ b/components/SubscribedCard/SubscribedCard.component.js
@@ -20,11 +20,12 @@ const SubscribedCard = (props) => {
                 onPress={() => {
                     setModalVisible(!isModalVisible)
                 }}>
-                <Text> {props.org} </Text>
-                <Text style={styles.title}> {props.title} </Text>
-                <Image style={styles.image} resizeMode="contain" source={props.source} />
-                <Text style={styles.date}> {props.date} </Text>
-                <Text> {props.link} </Text>
+                <Image style={styles.image} source={props.source} />
+                <Text style={styles.textContainer}>
+                    <Text style={styles.title}>{props.title}{"\n"}{"\n"}</Text>
+                    <Text>Theme: {props.theme}{"\n"}</Text>
+                    <Text>Perks: {props.perks}</Text>
+                </Text>
             </TouchableOpacity>
             <Modal animationType="slide"
                 transparent={true}

--- a/components/SubscribedCard/SubscribedCard.component.js
+++ b/components/SubscribedCard/SubscribedCard.component.js
@@ -1,36 +1,24 @@
 import React, { useState, useContext } from 'react';
-import { Text, Image, View, Alert } from 'react-native';
+import { Text, Image, View, Alert, Modal } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 
 import styles from './SubscribedCard.styles';
 
 import { UserContext } from '../../context/UserContext';
 
-let lastPress = 0;
+import Button from '../MainButton/MainButton.component';
 
 const SubscribedCard = (props) => {
 
+    const [isModalVisible, setModalVisible] = useState(false);
     const { userEvents, removeUserEvents } = useContext(UserContext);
-
-    const onDoublePress = () => {
-        const time = new Date().getTime();
-        const delta = time - lastPress;
-
-        const DOUBLE_PRESS_DELAY = 400;
-        if (delta < DOUBLE_PRESS_DELAY) {
-            removeUserEvents([...userEvents, props.title]);
-            Alert.alert("You have unsubscribed from " + props.title + " on " + props.date + ".");
-            console.log([...userEvents]);
-        }
-        lastPress = time;
-    };
 
     return (
         <View>
             <TouchableOpacity
                 style={styles.container}
                 onPress={() => {
-                    onDoublePress()
+                    setModalVisible(!isModalVisible)
                 }}>
                 <Text> {props.org} </Text>
                 <Text style={styles.title}> {props.title} </Text>
@@ -38,6 +26,34 @@ const SubscribedCard = (props) => {
                 <Text style={styles.date}> {props.date} </Text>
                 <Text> {props.link} </Text>
             </TouchableOpacity>
+            <Modal animationType="slide"
+                transparent={true}
+                visible={isModalVisible}>
+                <View style={styles.containerPopUp}>
+                    <Text> {props.org} </Text>
+                    <Text style={styles.titlePopUp}> {props.title} </Text>
+                    <Image style={styles.imagePopUp} resizeMode="contain" source={props.source} />
+                    <Text style={styles.datePopUp}> {props.date} </Text>
+                    <Text> {props.link} </Text>
+                    <Button
+                        onPress={() => {
+                            removeUserEvents([...userEvents, props.title]);
+                            setModalVisible(!isModalVisible);
+                            Alert.alert("You have unsubscribed from " + props.title + " on " + props.date + ".");
+                            console.log([...userEvents]);
+                        }}
+                        style={{ backgroundColor: '#92d050' }}
+                        label="Unsubscribe"
+                    />
+                    <Button
+                        onPress={() => {
+                            setModalVisible(!isModalVisible);
+                        }}
+                        style={{ backgroundColor: '#CD5C5C' }}
+                        label="Exit"
+                    />
+                </View>
+            </Modal>
         </View>
     )
 }

--- a/components/SubscribedCard/SubscribedCard.component.js
+++ b/components/SubscribedCard/SubscribedCard.component.js
@@ -22,7 +22,7 @@ const SubscribedCard = (props) => {
                 }}>
                 <Image style={styles.image} source={props.source} />
                 <Text style={styles.textContainer}>
-                    <Text style={styles.title}>{props.title}{"\n"}{"\n"}</Text>
+                    <Text style={styles.title}>{props.title}{"\n"}</Text>
                     <Text>Theme: {props.theme}{"\n"}</Text>
                     <Text>Perks: {props.perks}</Text>
                 </Text>
@@ -34,8 +34,8 @@ const SubscribedCard = (props) => {
                     <Text> {props.org} </Text>
                     <Text style={styles.titlePopUp}> {props.title} </Text>
                     <Image style={styles.imagePopUp} resizeMode="contain" source={props.source} />
+                    <Text style={styles.descPopUp}> {props.desc} </Text>
                     <Text style={styles.datePopUp}> {props.date} </Text>
-                    <Text> {props.link} </Text>
                     <Button
                         onPress={() => {
                             removeUserEvents([...userEvents, props.title]);

--- a/components/SubscribedCard/SubscribedCard.styles.js
+++ b/components/SubscribedCard/SubscribedCard.styles.js
@@ -37,6 +37,48 @@ const styles = StyleSheet.create({
     },
     date: {
     },
+
+    containerPopUp: {
+        marginTop: 10,
+        //flex: 1,
+        //flexDirection: 'row',
+        //justifyContent: 'space-between',
+        backgroundColor: 'white',
+        // width: width - 40,
+        margin: 10,
+        // height: height - 105,
+        alignItems: 'center',
+        borderRadius: 10,
+        padding: "5%",
+        shadowColor: 'black',
+        shadowOffset: {
+            width: 1,
+            height: 1
+        },
+        shadowOpacity: 0.24,
+        shadowRadius: 5,
+        elevation: 3
+    },
+    titlePopUp: {
+        fontWeight: 'bold',
+        fontSize: 25,
+    },
+    imagePopUp: {
+        width: "100%",
+        height: "60%",
+        //margin: "5%",
+        borderRadius: 10,
+    },
+    datePopUp: {
+        fontSize: 20
+    },
+    btnText: {
+        fontSize: 20,
+        textAlign: 'center',
+        textTransform: 'uppercase',
+        fontWeight: 'bold',
+        letterSpacing: 2
+    }
 });
 
 export default styles;

--- a/components/SubscribedCard/SubscribedCard.styles.js
+++ b/components/SubscribedCard/SubscribedCard.styles.js
@@ -5,14 +5,13 @@ const { height } = Dimensions.get('window');
 
 const styles = StyleSheet.create({
     container: {
-        marginTop: 10,
         //flex: 1,
-        //flexDirection: 'row',
+        flexDirection: 'row',
         //justifyContent: 'space-between',
         backgroundColor: 'white',
         width: width - 20,
         margin: 10,
-        height: height - 210,
+        //height: height - 210,
         alignItems: 'center',
         borderRadius: 10,
         padding: "5%",
@@ -25,17 +24,20 @@ const styles = StyleSheet.create({
         shadowRadius: 5,
         elevation: 3
     },
+    image: {
+        width: 100,
+        height: 100,
+        borderRadius: 5,
+    },
+    textContainer: {
+        flexDirection: 'column',
+        textAlign: "center",
+        flex: 1,
+        flexWrap: 'wrap',
+    },
     title: {
         fontWeight: 'bold',
-        fontSize: 25,
-    },
-    image: {
-        width: "100%",
-        height: "70%",
-        margin: "5%",
-        borderRadius: 10,
-    },
-    date: {
+        fontSize: 20,
     },
 
     containerPopUp: {
@@ -46,7 +48,7 @@ const styles = StyleSheet.create({
         backgroundColor: 'white',
         // width: width - 40,
         margin: 10,
-        // height: height - 105,
+        height: height - 105,
         alignItems: 'center',
         borderRadius: 10,
         padding: "5%",

--- a/components/SubscribedCard/SubscribedCard.styles.js
+++ b/components/SubscribedCard/SubscribedCard.styles.js
@@ -25,8 +25,8 @@ const styles = StyleSheet.create({
         elevation: 3
     },
     image: {
-        width: 100,
-        height: 100,
+        width: 75,
+        height: 75,
         borderRadius: 5,
     },
     textContainer: {
@@ -48,7 +48,7 @@ const styles = StyleSheet.create({
         backgroundColor: 'white',
         // width: width - 40,
         margin: 10,
-        height: height - 105,
+        // height: height - 105,
         alignItems: 'center',
         borderRadius: 10,
         padding: "5%",
@@ -66,13 +66,20 @@ const styles = StyleSheet.create({
         fontSize: 25,
     },
     imagePopUp: {
-        width: "100%",
-        height: "60%",
+        width: "80%",
+        height: "40%",
         //margin: "5%",
         borderRadius: 10,
     },
+    descPopUp: {
+        fontSize: 15,
+        textAlign: 'left',
+        width: '100%',
+        paddingVertical: '2%'
+    },
     datePopUp: {
-        fontSize: 20
+        fontSize: 20,
+        fontWeight: 'bold'
     },
     btnText: {
         fontSize: 20,

--- a/data/events.js
+++ b/data/events.js
@@ -1,6 +1,8 @@
 const dummyEvents = [
     {
         title: "Career Center Workshop",
+        theme: "Workshop",
+        perks: "+1 to attendance, free pizza",
         org: "Computer Science Society",
         desc: "This workshop is open to all students/all majors and alumni. Students will get information on how to market their essential skills to employers at the upcoming virtual career fairs. Students/alumni can click on the Zoom link to attend the presentation.",
         date: "Tuesday, May 10, 2020",
@@ -9,6 +11,8 @@ const dummyEvents = [
     },
     {
         title: "Capture The Flag",
+        theme: "Information Security Competition",
+        perks: "+1 to attendance",
         org: "Software Engineering Association",
         desc: "There will be an ongoing session throughout the day that will include a powerpoint presentation that teaches everyone the basics of CTFs as well as how they would be able to sign up and participate in the hosted competition.",
         date: "Saturday, November 17, 2019",
@@ -17,6 +21,8 @@ const dummyEvents = [
     },
     {
         title: "Guest Speaker: Lance Kimberlin from Bilizzard",
+        theme: "Q&A Session",
+        perks: "+1 to attendance, meet Lance, free tacos",
         org: "Computer Science Society",
         desc: "Tuesday, May 10, 2020",
         link: "https://github.com",

--- a/screens/CreateEvent/CreateEvent.component.js
+++ b/screens/CreateEvent/CreateEvent.component.js
@@ -22,7 +22,7 @@ const CreateEvent = () => {
         categories: [],
         startDate: new Date(),
         endDate: new Date(),
-        description: "",
+        desc: "",
         image: require('../../assets/images/space.jpg'),
     }
 
@@ -107,7 +107,7 @@ const CreateEvent = () => {
                 onChangeText={ text => {
                     setEventData(oldState => ({
                         ...oldState,
-                        description: text
+                        desc: text
                     }));
                 }}
                 multiline={true}

--- a/screens/Events/Events.component.js
+++ b/screens/Events/Events.component.js
@@ -14,32 +14,6 @@ import styles from './Events.styles';
 
 const { width } = Dimensions.get('window');
 
-const cardItems = [
-    {
-        title: "Career Center Workshop",
-        org: "Computer Science Society",
-        desc: "This workshop is open to all students/all majors and alumni. Students will get information on how to market their essential skills to employers at the upcoming virtual career fairs. Students/alumni can click on the Zoom link to attend the presentation.",
-        date: "Tuesday, May 10, 2020",
-        link: "https://github.com",
-        image: require("../../assets/images/CareerCenterWorkshop.jpg")
-    },
-    {
-        title: "Capture The Flag",
-        org: "Software Engineering Association",
-        desc: "There will be an ongoing session throughout the day that will include a powerpoint presentation that teaches everyone the basics of CTFs as well as how they would be able to sign up and participate in the hosted competition.",
-        date: "Saturday, November 17, 2019",
-        link: "https://github.com",
-        image: require("../../assets/images/CTF.png")
-    },
-    {
-        title: "Guest Speaker: Lance Kimberlin from Bilizzard",
-        org: "Computer Science Society",
-        date: "Tuesday, May 10, 2020",
-        link: "https://github.com",
-        image: require("../../assets/images/Blizzard.png")
-    },
-]
-
 const Events = ({navigation}) => {
 
     const [searchQuery, setSearchQuery] = React.useState('');
@@ -82,6 +56,9 @@ const Events = ({navigation}) => {
                     <EventCard
                        key={id}
                        title={card.title}
+                       // NOTE: Uncommenting the below comments will cause an error: Cannot find event variable
+                        // theme={event.theme}
+                        // perks={event.perks}
                        org={card.org}
                        desc={card.desc}
                        date={card.date}

--- a/screens/Events/Events.component.js
+++ b/screens/Events/Events.component.js
@@ -56,9 +56,8 @@ const Events = ({navigation}) => {
                     <EventCard
                        key={id}
                        title={card.title}
-                       // NOTE: Uncommenting the below comments will cause an error: Cannot find event variable
-                        // theme={event.theme}
-                        // perks={event.perks}
+                       theme={card.theme}
+                       perks={card.perks}
                        org={card.org}
                        desc={card.desc}
                        date={card.date}

--- a/screens/Feed/Feed.component.js
+++ b/screens/Feed/Feed.component.js
@@ -67,12 +67,14 @@ const Feed = () => {
   const eventList = allEvents.map((event, id) => (
     userEvents.indexOf(event.title) !== -1) ?
       (<SubscribedCard
-      key={id}
-      title={event.title}
-      org={event.org}
-      date={event.date}
-      link={event.link}
-      source={event.image}
+        key={id}
+        title={event.title}
+        theme={event.theme}
+        perks={event.perks}
+        org={event.org}
+        date={event.date}
+        link={event.link}
+        source={event.image}
     />) : console.log(event.id)
     
   );

--- a/screens/Feed/Feed.component.js
+++ b/screens/Feed/Feed.component.js
@@ -72,6 +72,7 @@ const Feed = () => {
         theme={event.theme}
         perks={event.perks}
         org={event.org}
+        desc={event.desc}
         date={event.date}
         link={event.link}
         source={event.image}


### PR DESCRIPTION
- Feed page cards are now like Club page cards with "Themes" and "Perks" instead of "Related to:"
- Reverted Feed page cards double tap back to Modal popup
- Popup now matches the Events page cards' popups but have an "Unsubscribe" button instead of an "RSVP" button
- Added dummy data for Themes and Perks
- Changed "description" to "desc" for newly created cards so the popups for both Events and Feed pages show the description. Later we will need to change "desc" to "info" like how Peter said for the backend data on Discord.