### PR TITLE
Added dates between Feed page cards

### DIFF
--- a/components/EventCard/EventCard.component.js
+++ b/components/EventCard/EventCard.component.js
@@ -12,7 +12,7 @@ const EventCard = (props) => {
 
     const [isModalVisible, setModalVisible] = useState(false);
     const { userEvents, setUserEvents } = useContext(UserContext);
-    const UTCDate = new Date(props.date).toString();
+    const UTCDate = new Date(props.startDate).toString();
     
     return(
         <View>
@@ -44,7 +44,7 @@ const EventCard = (props) => {
                     <Text style={styles.datePopUp}> {UTCDate} </Text>
                     <Button
                         onPress={() => {
-                            Alert.alert("You successfully have registered for " + props.title + " on " + props.date + "!");
+                            Alert.alert("You successfully have registered for " + props.title + " on " + props.startDate + "!");
                             setUserEvents([...userEvents, props.title]);
                             setModalVisible(!isModalVisible);
                             console.log([...userEvents, props.title]);

--- a/components/EventCard/EventCard.component.js
+++ b/components/EventCard/EventCard.component.js
@@ -12,6 +12,7 @@ const EventCard = (props) => {
 
     const [isModalVisible, setModalVisible] = useState(false);
     const { userEvents, setUserEvents } = useContext(UserContext);
+    const UTCDate = new Date(props.date).toString();
     
     return(
         <View>
@@ -23,7 +24,7 @@ const EventCard = (props) => {
                 <Text> {props.org} </Text>
                 <Text style={styles.title}> {props.title} </Text>
                 <Image style={styles.image} resizeMode="contain" source={props.source}/>
-                <Text style={styles.date}> {props.date} </Text>
+                <Text style={styles.date}> {UTCDate} </Text>
 
                 <Text> {props.link} </Text>
             </TouchableOpacity>
@@ -40,7 +41,7 @@ const EventCard = (props) => {
                     <Text style={styles.titlePopUp}> {props.title} </Text>
                     <Image style={styles.imagePopUp} resizeMode="contain" source={props.source} />
                     <Text style={styles.descPopUp}> {props.desc} </Text>
-                    <Text style={styles.datePopUp}> {props.date} </Text>
+                    <Text style={styles.datePopUp}> {UTCDate} </Text>
                     <Button
                         onPress={() => {
                             Alert.alert("You successfully have registered for " + props.title + " on " + props.date + "!");

--- a/components/SubscribedCard/SubscribedCard.component.js
+++ b/components/SubscribedCard/SubscribedCard.component.js
@@ -12,6 +12,7 @@ const SubscribedCard = (props) => {
 
     const [isModalVisible, setModalVisible] = useState(false);
     const { userEvents, removeUserEvents } = useContext(UserContext);
+    const UTCDate = new Date(props.date).toString();
 
     return (
         <View>
@@ -35,7 +36,7 @@ const SubscribedCard = (props) => {
                     <Text style={styles.titlePopUp}> {props.title} </Text>
                     <Image style={styles.imagePopUp} resizeMode="contain" source={props.source} />
                     <Text style={styles.descPopUp}> {props.desc} </Text>
-                    <Text style={styles.datePopUp}> {props.date} </Text>
+                    <Text style={styles.datePopUp}> {UTCDate} </Text>
                     <Button
                         onPress={() => {
                             removeUserEvents([...userEvents, props.title]);

--- a/components/SubscribedCard/SubscribedCard.component.js
+++ b/components/SubscribedCard/SubscribedCard.component.js
@@ -12,7 +12,7 @@ const SubscribedCard = (props) => {
 
     const [isModalVisible, setModalVisible] = useState(false);
     const { userEvents, removeUserEvents } = useContext(UserContext);
-    const UTCDate = new Date(props.date).toString();
+    const UTCDate = new Date(props.startDate).toString();
 
     return (
         <View>

--- a/data/events.js
+++ b/data/events.js
@@ -5,7 +5,7 @@ const dummyEvents = [
         perks: "+1 to attendance, free pizza",
         org: "Computer Science Society",
         desc: "This workshop is open to all students/all majors and alumni. Students will get information on how to market their essential skills to employers at the upcoming virtual career fairs. Students/alumni can click on the Zoom link to attend the presentation.",
-        date: "2020-5-10T01:01:01+00:00", //"Tuesday, May 10, 2020"
+        date: "2020-05-10T01:01:01+00:00", //"Tuesday, May 10, 2020"
         link: "https://github.com",
         image: require("../assets/images/CareerCenterWorkshop.jpg")
     },
@@ -25,7 +25,7 @@ const dummyEvents = [
         perks: "+1 to attendance, meet Lance, free tacos",
         org: "Computer Science Society",
         desc: "Sample description here",
-        date: "2020-5-10T01:01:01+00:00", //"Tuesday, May 10, 2020",
+        date: "2020-05-10T01:01:01+00:00", //"Tuesday, May 10, 2020",
         link: "https://github.com",
         image: require("../assets/images/Blizzard.png")
     },

--- a/data/events.js
+++ b/data/events.js
@@ -5,7 +5,7 @@ const dummyEvents = [
         perks: "+1 to attendance, free pizza",
         org: "Computer Science Society",
         desc: "This workshop is open to all students/all majors and alumni. Students will get information on how to market their essential skills to employers at the upcoming virtual career fairs. Students/alumni can click on the Zoom link to attend the presentation.",
-        date: "Tuesday, May 10, 2020",
+        date: "2020-5-10T01:01:01+00:00", //"Tuesday, May 10, 2020"
         link: "https://github.com",
         image: require("../assets/images/CareerCenterWorkshop.jpg")
     },
@@ -15,7 +15,7 @@ const dummyEvents = [
         perks: "+1 to attendance",
         org: "Software Engineering Association",
         desc: "There will be an ongoing session throughout the day that will include a powerpoint presentation that teaches everyone the basics of CTFs as well as how they would be able to sign up and participate in the hosted competition.",
-        date: "Saturday, November 17, 2019",
+        date: "2019-11-17T01:01:01+00:00", //"Saturday, November 17, 2019",
         link: "https://github.com",
         image: require("../assets/images/CTF.png")
     },
@@ -24,7 +24,8 @@ const dummyEvents = [
         theme: "Q&A Session",
         perks: "+1 to attendance, meet Lance, free tacos",
         org: "Computer Science Society",
-        desc: "Tuesday, May 10, 2020",
+        desc: "Sample description here",
+        date: "2020-5-10T01:01:01+00:00", //"Tuesday, May 10, 2020",
         link: "https://github.com",
         image: require("../assets/images/Blizzard.png")
     },

--- a/data/events.js
+++ b/data/events.js
@@ -5,7 +5,7 @@ const dummyEvents = [
         perks: "+1 to attendance, free pizza",
         org: "Computer Science Society",
         desc: "This workshop is open to all students/all majors and alumni. Students will get information on how to market their essential skills to employers at the upcoming virtual career fairs. Students/alumni can click on the Zoom link to attend the presentation.",
-        date: "2020-05-10T01:01:01+00:00", //"Tuesday, May 10, 2020"
+        startDate: "2020-05-10T01:01:01+00:00", //"Tuesday, May 10, 2020"
         link: "https://github.com",
         image: require("../assets/images/CareerCenterWorkshop.jpg")
     },
@@ -15,7 +15,7 @@ const dummyEvents = [
         perks: "+1 to attendance",
         org: "Software Engineering Association",
         desc: "There will be an ongoing session throughout the day that will include a powerpoint presentation that teaches everyone the basics of CTFs as well as how they would be able to sign up and participate in the hosted competition.",
-        date: "2019-11-17T01:01:01+00:00", //"Saturday, November 17, 2019",
+        startDate: "2019-11-17T01:01:01+00:00", //"Saturday, November 17, 2019",
         link: "https://github.com",
         image: require("../assets/images/CTF.png")
     },
@@ -25,7 +25,7 @@ const dummyEvents = [
         perks: "+1 to attendance, meet Lance, free tacos",
         org: "Computer Science Society",
         desc: "Sample description here",
-        date: "2020-05-10T01:01:01+00:00", //"Tuesday, May 10, 2020",
+        startDate: "2020-05-10T01:01:01+00:00", //"Tuesday, May 10, 2020",
         link: "https://github.com",
         image: require("../assets/images/Blizzard.png")
     },

--- a/screens/Events/Events.component.js
+++ b/screens/Events/Events.component.js
@@ -60,7 +60,7 @@ const Events = ({navigation}) => {
                        perks={card.perks}
                        org={card.org}
                        desc={card.desc}
-                       date={card.date}
+                       startDate={card.startDate}
                        link={card.link}
                        source={card.image}
                     />

--- a/screens/Events/Events.component.js
+++ b/screens/Events/Events.component.js
@@ -8,6 +8,7 @@ import Button from '../../components/MainButton/MainButton.component';
 
 // Context
 import { EventContext } from '../../context/EventContext';
+import { UserContext } from '../../context/UserContext';
 
 // Styles
 import styles from './Events.styles';
@@ -20,6 +21,7 @@ const Events = ({navigation}) => {
     const onChangeSearch = query => setSearchQuery(query);
 
     const { allEvents } = useContext(EventContext);
+    const { userEvents } = useContext(UserContext);
     let filteredCards = allEvents.filter(
         (event) => {
             return event.org.toLowerCase().indexOf(searchQuery.toLowerCase()) !== -1;
@@ -52,8 +54,9 @@ const Events = ({navigation}) => {
                    bottom: 0,
                    right: 30
                }}>
-               {filteredCards.map((card, id) =>
-                    <EventCard
+                {filteredCards.map((card, id) =>
+                    (userEvents.indexOf(card.title) === -1) ?
+                    (<EventCard
                        key={id}
                        title={card.title}
                        theme={card.theme}
@@ -63,7 +66,7 @@ const Events = ({navigation}) => {
                        startDate={card.startDate}
                        link={card.link}
                        source={card.image}
-                    />
+                        />) : console.log(card.id)
                )} 
             </ScrollView>
 

--- a/screens/Events/Events.component.js
+++ b/screens/Events/Events.component.js
@@ -54,7 +54,8 @@ const Events = ({navigation}) => {
                    bottom: 0,
                    right: 30
                }}>
-                {filteredCards.map((card, id) =>
+                {filteredCards.sort((a, b) => (a.startDate > b.startDate) ? 1 :
+                    ((b.startDate > a.startDate) ? -1 : 0)).map((card, id) =>
                     (userEvents.indexOf(card.title) === -1) ?
                     (<EventCard
                        key={id}

--- a/screens/Feed/Feed.component.js
+++ b/screens/Feed/Feed.component.js
@@ -66,11 +66,10 @@ const Feed = () => {
         }, 
     []);
 
-    // Checks the date if it is new.
-    // If date is new, return element
+    // Checks the startDate if it is new.
+    // If startDate is new, return element
     // If not, return null 
     const getDate = (data) => {
-        let strDate = JSON.stringify(data).split("T")[0];
         let UTCDate = new Date(data).toString().split(" ");
         let returnDate = "";
 
@@ -86,10 +85,10 @@ const Feed = () => {
             }
         }
 
-        if (currDate === strDate) {
+        if (currDate === returnDate) {
             return null;
         } else {
-            currDate = strDate;
+            currDate = returnDate;
             return <Text style={styles.dateBetweenCards}>{returnDate}</Text>;
         }
     }
@@ -98,7 +97,7 @@ const Feed = () => {
         ((b[Object.keys(b)[5]] > a[Object.keys(a)[5]]) ? -1 : 0)).map((event, id) => 
         (userEvents.indexOf(event.title) !== -1) ?
         (<View>
-            {getDate(event.date)}
+            {getDate(event.startDate)}
             <SubscribedCard
             key={id}
             title={event.title}
@@ -106,7 +105,7 @@ const Feed = () => {
             perks={event.perks}
             org={event.org}
             desc={event.desc}
-            date={event.date}
+            startDate={event.startDate}
             link={event.link}
             source={event.image}
             />

--- a/screens/Feed/Feed.component.js
+++ b/screens/Feed/Feed.component.js
@@ -12,81 +12,109 @@ import { EventContext } from '../../context/EventContext';
 const axios = require("axios");
 
 const Feed = () => {
-  //const [events, setEvents] = useState([]);
-  const { allEvents } = useContext(EventContext);
-  const { userEvents } = useContext(UserContext);
+    //const [events, setEvents] = useState([]);
+    const { allEvents } = useContext(EventContext);
+    const { userEvents } = useContext(UserContext);
+    let currDate = null;
 
-  useEffect(() => {
-    const getEvents = async () => {
-      const url = "https://jsonplaceholder.typicode.com/posts"; // temporary
-      
-      const settings = {
-        headers: {
-          "Content-Type": "application/json",
-        },
-      };
+    useEffect(() => {
+        const getEvents = async () => {
+            const url = "https://jsonplaceholder.typicode.com/posts"; // temporary
+            
+            const settings = {
+                    headers: {
+                    "Content-Type": "application/json",
+                    },
+                };
 
-      try {
-        let response = await axios.get(url, settings);
-        //console.log(response);
-        /*
-        setEvents([
-          {
-            id: 1,
-            title: "Career Center Workshop",
-            org: "Computer Science Society",
-            date: "Tuesday, May 10, 2020",
-            link: "https://github.com",
-            image: require("../../assets/images/CareerCenterWorkshop.jpg")
-          },
-          {
-            id: 2,
-            title: "Capture The Flag",
-            org: "Software Engineering Association",
-            date: "Saturday, November 17, 2019",
-            link: "https://github.com",
-            image: require("../../assets/images/CTF.png")
-          },
-          {
-            id: 3,
-            title: "Guest Speaker: Lance Kimberlin from Bilizzard",
-            org: "Computer Science Society",
-            date: "Tuesday, May 10, 2020",
-            link: "https://github.com",
-            image: require("../../assets/images/Blizzard.png")
-          },
-        ]); // hardcoded for now
-        */
-      } catch (error) {
-        console.error(error);
-      }
-    };
-    getEvents();
-  }, []);
+                try {
+                    let response = await axios.get(url, settings);
+                    //console.log(response);
+                    /*
+                    setEvents([
+                    {
+                        id: 1,
+                        title: "Career Center Workshop",
+                        org: "Computer Science Society",
+                        date: "Tuesday, May 10, 2020",
+                        link: "https://github.com",
+                        image: require("../../assets/images/CareerCenterWorkshop.jpg")
+                    },
+                    {
+                        id: 2,
+                        title: "Capture The Flag",
+                        org: "Software Engineering Association",
+                        date: "Saturday, November 17, 2019",
+                        link: "https://github.com",
+                        image: require("../../assets/images/CTF.png")
+                    },
+                    {
+                        id: 3,
+                        title: "Guest Speaker: Lance Kimberlin from Bilizzard",
+                        org: "Computer Science Society",
+                        date: "Tuesday, May 10, 2020",
+                        link: "https://github.com",
+                        image: require("../../assets/images/Blizzard.png")
+                    },
+                    ]); // hardcoded for now
+                    */
+                } catch (error) {
+                    console.error(error);
+                }
+            };
+            getEvents();
+        }, 
+    []);
+
+    // Checks the date if it is new.
+    // If date is new, return element
+    // If not, return null 
+    const getDate = (data) => {
+        let strDate = JSON.stringify(data).split("T")[0];
+        let UTCDate = new Date(data).toString().split(" ");
+        let returnDate = "";
+
+        for ( let i = 0; i < 4; i++ ) {
+            if ( i % 2 == 0 ) {
+                returnDate += " " + UTCDate[i];
+            } else {
+                returnDate += ", " + UTCDate[i];
+            }
+        }
+
+        if (currDate === strDate) {
+            return null;
+        } else {
+            currDate = strDate;
+            return <Text style={styles.dateBetweenCards}>{returnDate}</Text>;
+        }
+    }
 
     const eventList = allEvents.sort((a, b) => (a[Object.keys(a)[5]] > b[Object.keys(b)[5]]) ? 1 :
-        ((b[Object.keys(b)[5]] > a[Object.keys(a)[5]]) ? -1 : 0)).map((event, id) => (
-    userEvents.indexOf(event.title) !== -1) ?
-      (<SubscribedCard
-        key={id}
-        title={event.title}
-        theme={event.theme}
-        perks={event.perks}
-        org={event.org}
-        desc={event.desc}
-        date={event.date}
-        link={event.link}
-        source={event.image}
-    />) : console.log(event.id)
-    
-  );
-  return (
-    <View style={styles.layout}>
-      <ScrollView showsVerticalScrollIndicator={false}>
-        {eventList}
-      </ScrollView>
-    </View>
-  );
+        ((b[Object.keys(b)[5]] > a[Object.keys(a)[5]]) ? -1 : 0)).map((event, id) => 
+        (userEvents.indexOf(event.title) !== -1) ?
+        (<View>
+            {getDate(event.date)}
+            <SubscribedCard
+            key={id}
+            title={event.title}
+            theme={event.theme}
+            perks={event.perks}
+            org={event.org}
+            desc={event.desc}
+            date={event.date}
+            link={event.link}
+            source={event.image}
+            />
+        </View>) : console.log(event.id)
+    );
+    return (
+        <View style={styles.layout}>
+        <ScrollView showsVerticalScrollIndicator={false}>
+            {eventList}
+        </ScrollView>
+        </View>
+    );
 };
 
 export default Feed;

--- a/screens/Feed/Feed.component.js
+++ b/screens/Feed/Feed.component.js
@@ -64,7 +64,8 @@ const Feed = () => {
     getEvents();
   }, []);
 
-  const eventList = allEvents.map((event, id) => (
+    const eventList = allEvents.sort((a, b) => (a[Object.keys(a)[5]] > b[Object.keys(b)[5]]) ? 1 :
+        ((b[Object.keys(b)[5]] > a[Object.keys(a)[5]]) ? -1 : 0)).map((event, id) => (
     userEvents.indexOf(event.title) !== -1) ?
       (<SubscribedCard
         key={id}

--- a/screens/Feed/Feed.component.js
+++ b/screens/Feed/Feed.component.js
@@ -76,9 +76,13 @@ const Feed = () => {
 
         for ( let i = 0; i < 4; i++ ) {
             if ( i % 2 == 0 ) {
-                returnDate += " " + UTCDate[i];
+                if ( i == 2 && UTCDate[2][0] == "0" ) {
+                    returnDate += UTCDate[i][1] + ", ";
+                } else {
+                    returnDate += UTCDate[i] + ", ";
+                }
             } else {
-                returnDate += ", " + UTCDate[i];
+                returnDate += UTCDate[i] + " ";
             }
         }
 

--- a/screens/Feed/Feed.component.js
+++ b/screens/Feed/Feed.component.js
@@ -93,8 +93,8 @@ const Feed = () => {
         }
     }
 
-    const eventList = allEvents.sort((a, b) => (a[Object.keys(a)[5]] > b[Object.keys(b)[5]]) ? 1 :
-        ((b[Object.keys(b)[5]] > a[Object.keys(a)[5]]) ? -1 : 0)).map((event, id) => 
+    const eventList = allEvents.sort((a, b) => (a.startDate > b.startDate) ? 1 :
+        ((b.startDate > a.startDate) ? -1 : 0)).map((event, id) => 
         (userEvents.indexOf(event.title) !== -1) ?
         (<View>
             {getDate(event.startDate)}

--- a/screens/Feed/Feed.styles.js
+++ b/screens/Feed/Feed.styles.js
@@ -29,6 +29,12 @@ const styles = StyleSheet.create({
         borderWidth: 1,
         borderRadius: 16,
     },
+    dateBetweenCards: {
+        textAlign: 'center',
+        color: '#111111',
+        fontSize: 24,
+        margin: 2.5,
+    }
 });
 
 export default styles;


### PR DESCRIPTION
**Feed Page**
- Sorted by date (most upcoming events)
- Same dates will stack the cards and not show the same date again
- Formatting Example: Sat, Nov 16, 2019
- Popup card has UTC date formatting, **but the time zone is wrong so it will show a day before.**
- Indents updated for 4 spaces

**Events Page**
- **WARNING** from emulator after RVSP button press: **Each child in a list should have a unique "key" prop**
- Sorted by date (most upcoming events)
- Non-expanded card: Has UTC date formatting
- Popup card: Has UTC date formatting
- NOTE: Cannot add newly created Event cards to Feed page some error like: undefined can't be used in JSON.stringify(data).split( Update: FIXED

**Dummy Data in data/events.js**
- Updated "date"s with backend formatting (ISO)
- NOTE: "date" will need to be renamed to "startDate" later. Update: FIXED

Please merge if no issues after checking.